### PR TITLE
Fix unused result of read

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -57,7 +57,10 @@ InputAction Input::get(bool block)
     }
   }
 
-  read(tty_fno, &usr_cmd, sizeof(int));
+  if(read(tty_fno, &usr_cmd, sizeof(int)) < 0)
+  {
+    return Quit;
+  }
 
   if((usr_cmd == 'q') || (usr_cmd == 'Q') || (usr_cmd == '\4'))
   {


### PR DESCRIPTION
I'm getting the following warning turning error because of `-Werror` using 8c6f26215dd42923ae45412c784fe10f6f726dc9:

```
/tmp/mattext/src/input.cpp:60:39: error: ignoring return value of 'ssize_t read(int, void*, size_t)', declared with attribute warn_unused_result [-Werror=unused-result]
   read(tty_fno, &usr_cmd, sizeof(int));
                                       ^
```

I don't think my patch is the best way to handle it since it just quits rather than actually handling the error, just decline if not good, or tell me how you (@dhurum) want to handle this if you don't want to do it yourself.

By the way, shouldn't this be happening to everyone? Or only GCC 4.8.4 is meticulous to `-Werror`?